### PR TITLE
Return null if no attachment found in getAttachmentByID method

### DIFF
--- a/App/Media.php
+++ b/App/Media.php
@@ -31,13 +31,13 @@ class Media implements WordPressHooks
      *
      * @param $attachment_id
      *
-     * @return object
+     * @return null|object
      */
     public static function getAttachmentByID($attachment_id)
     {
         $attachment = acf_get_attachment($attachment_id);
 
-        return (object)$attachment;
+        return $attachment ? (object) $attachment : null;
     }
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.3] - 2023-03-21
+
+### Changed
+
+- Media class getAttachmentByID method returns null if no attachment was found.
+
 ## [3.1.2] - 2023-02-20
 
 ### Changed

--- a/functions.php
+++ b/functions.php
@@ -23,7 +23,7 @@ use MC\App\Fields\FieldGroups\PageBuilderFieldGroup;
  * Define Theme Version
  * Define Theme directories
  */
-define('THEME_VERSION', '3.1.2');
+define('THEME_VERSION', '3.1.3');
 define('MC_THEME_DIR', trailingslashit(get_template_directory()));
 define('MC_THEME_PATH_URL', trailingslashit(get_template_directory_uri()));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-wp-starter-theme",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Starter wordpress theme",
   "author": "Modern Climate",
   "repository": {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://modernclimate.com
 Author: Modern Climate
 Author URI: http://modernclimate.com
 Description: A starter framework for WordPress themes.
-Version: 3.1.2
+Version: 3.1.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: mc-starter


### PR DESCRIPTION
### Description
- getAttachmentByID would return an empty object if no attachment was found. It now returns null if that is the case.

Link to Jira Ticket:
N/A

---

### Code Checklist

- [x] tested
- [x] documented
