### PR TITLE
Missing primary id on page builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Change starter modules in section rather than div
 - Switch @globals in included starter modules to @var and add types then add missing $row_id variable
 - uikit: add visibility scss include. Add uikit js parallax imports to slider/slideshow
+- Add id="primary" to all templates needing it
 
 ## [3.1.5] - 2023-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added a style hook to each module and added the hook action to the Module class
 - Change starter modules in section rather than div
 - Switch @globals in included starter modules to @var and add types then add missing $row_id variable
+- uikit: add visibility scss include. Add uikit js parallax imports to slider/slideshow
 
 ## [3.1.5] - 2023-04-24
 

--- a/assets/scripts/theme/UIkit.js
+++ b/assets/scripts/theme/UIkit.js
@@ -1,11 +1,17 @@
 import UIkit from 'uikit/dist/js/uikit-core';
+// import Parallax from 'uikit/src/js/components/parallax';
 import Slider from 'uikit/src/js/components/slider';
+// import SliderParallax from 'uikit/src/js/components/slider-parallax';
 import Slideshow from 'uikit/src/js/components/slideshow';
+// import SlideshowParallax from 'uikit/src/js/components/slideshow-parallax';
 
 // Add individual components imported from UIKit below
 const components = [
+  // { name: 'parallax', component: Parallax },
   { name: 'slider', component: Slider },
+  // { name: 'slider-parallax', component: SliderParallax },
   { name: 'slideshow', component: Slideshow },
+  // { name: 'slideshow-parallax', component: SlideshowParallax },
 ];
 
 components.forEach(({ name, component }) => {

--- a/assets/styles/vendors/_custom-ui-kit.scss
+++ b/assets/styles/vendors/_custom-ui-kit.scss
@@ -3,6 +3,8 @@
 @import 'node_modules/uikit/src/scss/mixins-theme.scss';
 
 // Import component styles from UIkit here. Documentation can be found at [https://getuikit.com/docs/introduction].
+
+// Layout
 @import 'node_modules/uikit/src/scss/components/container.scss';
 @import 'node_modules/uikit/src/scss/components/dotnav.scss';
 @import 'node_modules/uikit/src/scss/components/flex.scss';
@@ -10,8 +12,10 @@
 @import 'node_modules/uikit/src/scss/components/margin.scss';
 @import 'node_modules/uikit/src/scss/components/padding.scss';
 @import 'node_modules/uikit/src/scss/components/position.scss';
+@import 'node_modules/uikit/src/scss/components/visibility.scss';
+@import 'node_modules/uikit/src/scss/components/width.scss';
+
+// Components
 @import 'node_modules/uikit/src/scss/components/slidenav.scss';
 @import 'node_modules/uikit/src/scss/components/slider.scss';
 @import 'node_modules/uikit/src/scss/components/slideshow.scss';
-@import 'node_modules/uikit/src/scss/components/visibility.scss';
-@import 'node_modules/uikit/src/scss/components/width.scss';

--- a/templates/page-builder.php
+++ b/templates/page-builder.php
@@ -10,8 +10,14 @@
  */
 
 get_header();
+?>
 
-// hook: App/Fields/Modules/outputFlexibleModules()
-do_action('mc/modules/output', get_the_ID());
+<div id="primary">
+    <?php
+    // hook: App/Fields/Modules/outputFlexibleModules()
+    do_action('mc/modules/output', get_the_ID());
+    ?>
+</div><!-- /#primary -->'
 
+<?php
 get_footer();


### PR DESCRIPTION
### Description
- uikit: add visibility scss include. Add example code for uikit js parallax imports to slider/slideshow (is commented out).
- Add id="primary" to all templates needing it

Link to Jira Ticket:
[ADMC-49](https://modernclimate.atlassian.net/browse/ADMC-49)

---

### Code Checklist

- [x] tested
- [x] documented


[ADMC-49]: https://modernclimate.atlassian.net/browse/ADMC-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ