### PR TITLE
Add getTermMeta method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Versions
 
+## [3.1.8] - 2023-07-17
+
+### Changed
+
+- Added an ACF class method called getTermMeta that gets and caches term meta similarly to how getPostMeta works.
+
 ## [3.1.7] - 2023-05-17
 
 ### Changed

--- a/functions.php
+++ b/functions.php
@@ -23,7 +23,7 @@ use MC\App\Fields\FieldGroups\PageBuilderFieldGroup;
  * Define Theme Version
  * Define Theme directories
  */
-define('THEME_VERSION', '3.1.7');
+define('THEME_VERSION', '3.1.8');
 define('MC_THEME_DIR', trailingslashit(get_template_directory()));
 define('MC_THEME_PATH_URL', trailingslashit(get_template_directory_uri()));
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://modernclimate.com
 Author: Modern Climate
 Author URI: http://modernclimate.com
 Description: A starter framework for WordPress themes.
-Version: 3.1.7
+Version: 3.1.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: mc-starter


### PR DESCRIPTION
### Description

What:
Create ACF getTermMeta method similar to getPostMeta.

Usage:
```
$my_term_meta = ACF::getTermMeta($term_id);
$some_meta_value = ACF::getField('some-field', $my_term_meta);
```